### PR TITLE
Fallback to backport

### DIFF
--- a/etherscan/etherscan.py
+++ b/etherscan/etherscan.py
@@ -1,5 +1,8 @@
 import json
-from importlib import resources
+try:
+    from importlib import resources
+except ImportError:
+    import importlib_resources as resources
 
 import requests
 


### PR DESCRIPTION
Auto fallback to use the backport for pre 3.7 pythons.

Stumbled upon that trying to run on a Python3.6 setup.