### PR TITLE
Add support for Polygon / Configurable PREFIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs
 
 # eggs
 *egg*
+
+logs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include etherscan/configs/GOERLI-stable.json
 include etherscan/configs/KOVAN-stable.json
 include etherscan/configs/RINKEBY-stable.json
 include etherscan/configs/ROPSTEN-stable.json
+include etherscan/configs/POLYGON-stable.json
+include etherscan/configs/MUMBAI-stable.json

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ In `bash`, test that everything looks OK on your end using your `YOUR_API_KEY` (
 
 ``` bash
 bash run_tests.sh YOUR_API_KEY
+
+# If you want to run tests on specific networks
+export TEST_ON_NETS="POLYGON,MUMBAI"
+bash run_tests.sh YOUR_API_KEY
 ````
 
 This will regenerate the logs under `logs/` with the most recent results and the timestamp of the execution.

--- a/etherscan/configs/MUMBAI-stable.json
+++ b/etherscan/configs/MUMBAI-stable.json
@@ -1,0 +1,301 @@
+{
+  "_PREFIX": "https://api-testnet.polygonscan.com/api?",
+  "get_proxy_block_number": {
+    "module": "proxy",
+    "kwargs": {}
+  },
+  "get_proxy_block_by_number": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x10d4f"
+    }
+  },
+  "get_proxy_uncle_by_block_number_and_index": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x4d50e2",
+      "index": "0x0"
+    }
+  },
+  "get_proxy_block_transaction_count_by_number": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x10FB78"
+    }
+  },
+  "get_proxy_transaction_by_hash": {
+    "module": "proxy",
+    "kwargs": {
+      "txhash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1"
+    }
+  },
+  "get_proxy_transaction_by_block_number_and_index": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x43195c",
+      "index": "0x0"
+    }
+  },
+  "get_proxy_transaction_count": {
+    "module": "proxy",
+    "kwargs": {
+      "address": "0x2910543af39aba0cd09dbb2d50200b3e800a63d2"
+    }
+  },
+  "get_proxy_transaction_receipt": {
+    "module": "proxy",
+    "kwargs": {
+      "txhash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1"
+    }
+  },
+  "get_proxy_call": {
+    "module": "proxy",
+    "kwargs": {
+      "to": "0xAEEF46DB4855E25702F8237E8f403FddcaF931C0",
+      "data": "0x70a08231000000000000000000000000e16359506c028e51f16be38986ec5746251e9724"
+    }
+  },
+  "get_proxy_code_at": {
+    "module": "proxy",
+    "kwargs": {
+      "address": "0xf75e354c5edc8efed9b59ee9f67a80845ade7d0c"
+    }
+  },
+  "get_proxy_storage_position_at": {
+    "module": "proxy",
+    "kwargs": {
+      "position": "0x0",
+      "address": "0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd"
+    }
+  },
+  "get_proxy_gas_price": {
+    "module": "proxy",
+    "kwargs": {}
+  },
+  "get_proxy_est_gas": {
+    "module": "proxy",
+    "kwargs": {
+      "data": "0x4e71d92d",
+      "to": "0xf0160428a8552ac9bb7e050d90eeade4ddd52843",
+      "value": "0xff22",
+      "gas_price": "0x51da038cc",
+      "gas": "0x5f5e0ff"
+    }
+  },
+  "get_block_reward_by_block_number": {
+    "module": "blocks",
+    "kwargs": {
+      "block_no": "2165403"
+    }
+  },
+  "get_est_block_countdown_time_by_block_number": {
+    "module": "blocks",
+    "kwargs": {
+      "block_no": "99999999"
+    }
+  },
+  "get_block_number_by_timestamp": {
+    "module": "blocks",
+    "kwargs": {
+      "timestamp": "1578638524",
+      "closest": "before"
+    }
+  },
+  "get_total_eth_supply": {
+    "module": "stats",
+    "kwargs": {}
+  },
+  "get_eth_last_price": {
+    "module": "stats",
+    "kwargs": {}
+  },
+  "_get_eth_nodes_size": {
+    "module": "stats",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "client_type": "geth",
+      "sync_mode": "default",
+      "sort": "asc"
+    }
+  },
+  "get_total_supply_by_contract_address": {
+    "module": "tokens",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055"
+    }
+  },
+  "get_acc_balance_by_token_and_contract_address": {
+    "module": "tokens",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055",
+      "address": "0xe04f27eb70e025b78871a2ad7eabe85e61212761"
+    }
+  },
+  "get_contract_abi": {
+    "module": "contracts",
+    "kwargs": {
+      "address": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"
+    }
+  },
+  "get_contract_source_code": {
+    "module": "contracts",
+    "kwargs": {
+      "address": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"
+    }
+  },
+  "get_contract_execution_status": {
+    "module": "transactions",
+    "kwargs": {
+      "txhash": "0x15f8e5ea1079d9a0bb04a4c58ae5fe7654b5b2b4463375ff7ffb490aa0032f3a"
+    }
+  },
+  "get_tx_receipt_status": {
+    "module": "transactions",
+    "kwargs": {
+      "txhash": "0x513c1ba0bebf66436b5fed86ab668452b7805593c05073eb2d51d3a52f480a76"
+    }
+  },
+  "get_eth_balance": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a"
+    }
+  },
+  "get_eth_balance_multiple": {
+    "module": "accounts",
+    "kwargs": {
+      "addresses": [
+        "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a",
+        "0x63a9975ba31b0b9626b34300f7f627147df1f526",
+        "0x198ef1ec325a96cc354c7266a038be8b5c558f67"
+      ]
+    }
+  },
+  "get_normal_txs_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x539fe6aD90931e02F902618d0e33D326F670B89C",
+      "startblock": 0,
+      "endblock": 99999999,
+      "sort": "asc"
+    }
+  },
+  "get_normal_txs_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x539fe6aD90931e02F902618d0e33D326F670B89C",
+      "startblock": 0,
+      "endblock": 99999999,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xaaad7966ebe0663b8c9c6f683fb9c3e66e03467f",
+      "startblock": 23799593,
+      "endblock": 23799593,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xaaad7966ebe0663b8c9c6f683fb9c3e66e03467f",
+      "startblock": 23799593,
+      "endblock": 23799593,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_txhash": {
+    "module": "accounts",
+    "kwargs": {
+      "txhash": "0xad550ebc0f2473e3b5af8d1d30b093749cb2835bf21ed340e976b1ec25276b04"
+    }
+  },
+  "get_internal_txs_by_block_range_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "startblock": 0,
+      "endblock": 2702578,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xa991b15e414ddfa78b0df1f7af6b3cf2023c738d",
+      "startblock": 0,
+      "endblock": 999999999,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_contract_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x8fe80f7ca77daa68b059f8b3e29e1c5d962f01e7",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_address_and_contract_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x8fe80f7ca77daa68b059f8b3e29e1c5d962f01e7",
+      "address": "0xa991b15e414ddfa78b0df1f7af6b3cf2023c738d",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x57e05dba059a8ff2777408e9e1f3c517c20fc719",
+      "startblock": 0,
+      "endblock": 999999999,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_contract_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x953067757ec1b3a859f80ae15269f95430e72e69",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_address_and_contract_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x953067757ec1b3a859f80ae15269f95430e72e69",
+      "address": "0x57e05dba059a8ff2777408e9e1f3c517c20fc719",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_mined_blocks_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  "get_mined_blocks_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "page": 1,
+      "offset": 100
+    }
+  }
+}

--- a/etherscan/configs/POLYGON-stable.json
+++ b/etherscan/configs/POLYGON-stable.json
@@ -1,0 +1,457 @@
+{
+  "_PREFIX": "https://api.polygonscan.com/api?",
+  "get_proxy_block_number": {
+    "module": "proxy",
+    "kwargs": {}
+  },
+  "get_proxy_block_by_number": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x10d4f"
+    }
+  },
+  "get_proxy_uncle_by_block_number_and_index": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x210A9B",
+      "index": "0x0"
+    }
+  },
+  "get_proxy_block_transaction_count_by_number": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x10FB78"
+    }
+  },
+  "get_proxy_transaction_by_hash": {
+    "module": "proxy",
+    "kwargs": {
+      "txhash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1"
+    }
+  },
+  "get_proxy_transaction_by_block_number_and_index": {
+    "module": "proxy",
+    "kwargs": {
+      "tag": "0x10d4f",
+      "index": "0x0"
+    }
+  },
+  "get_proxy_transaction_count": {
+    "module": "proxy",
+    "kwargs": {
+      "address": "0x2910543af39aba0cd09dbb2d50200b3e800a63d2"
+    }
+  },
+  "get_proxy_transaction_receipt": {
+    "module": "proxy",
+    "kwargs": {
+      "txhash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1"
+    }
+  },
+  "get_proxy_call": {
+    "module": "proxy",
+    "kwargs": {
+      "to": "0xAEEF46DB4855E25702F8237E8f403FddcaF931C0",
+      "data": "0x70a08231000000000000000000000000e16359506c028e51f16be38986ec5746251e9724"
+    }
+  },
+  "get_proxy_code_at": {
+    "module": "proxy",
+    "kwargs": {
+      "address": "0xf75e354c5edc8efed9b59ee9f67a80845ade7d0c"
+    }
+  },
+  "get_proxy_storage_position_at": {
+    "module": "proxy",
+    "kwargs": {
+      "position": "0x0",
+      "address": "0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd"
+    }
+  },
+  "get_proxy_gas_price": {
+    "module": "proxy",
+    "kwargs": {}
+  },
+  "get_proxy_est_gas": {
+    "module": "proxy",
+    "kwargs": {
+      "data": "0x4e71d92d",
+      "to": "0xf0160428a8552ac9bb7e050d90eeade4ddd52843",
+      "value": "0xff22",
+      "gas_price": "0x51da038cc",
+      "gas": "0x5f5e0ff"
+    }
+  },
+  "get_block_reward_by_block_number": {
+    "module": "blocks",
+    "kwargs": {
+      "block_no": "2165403"
+    }
+  },
+  "get_est_block_countdown_time_by_block_number": {
+    "module": "blocks",
+    "kwargs": {
+      "block_no": "99999999"
+    }
+  },
+  "get_block_number_by_timestamp": {
+    "module": "blocks",
+    "kwargs": {
+      "timestamp": "1578638524",
+      "closest": "before"
+    }
+  },
+  "get_total_eth_supply": {
+    "module": "stats",
+    "kwargs": {}
+  },
+  "get_eth_last_price": {
+    "module": "stats",
+    "kwargs": {}
+  },
+  "get_eth_nodes_size": {
+    "module": "stats",
+    "kwargs": {
+      "start_date": "2021-02-01",
+      "end_date": "2021-02-28",
+      "client_type": "geth",
+      "sync_mode": "default",
+      "sort": "asc"
+    }
+  },
+  "get_total_supply_by_contract_address": {
+    "module": "tokens",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055"
+    }
+  },
+  "get_acc_balance_by_token_and_contract_address": {
+    "module": "tokens",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055",
+      "address": "0xe04f27eb70e025b78871a2ad7eabe85e61212761"
+    }
+  },
+  "get_contract_abi": {
+    "module": "contracts",
+    "kwargs": {
+      "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
+    }
+  },
+  "get_contract_source_code": {
+    "module": "contracts",
+    "kwargs": {
+      "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
+    }
+  },
+  "get_contract_execution_status": {
+    "module": "transactions",
+    "kwargs": {
+      "txhash": "0x15f8e5ea1079d9a0bb04a4c58ae5fe7654b5b2b4463375ff7ffb490aa0032f3a"
+    }
+  },
+  "get_tx_receipt_status": {
+    "module": "transactions",
+    "kwargs": {
+      "txhash": "0x513c1ba0bebf66436b5fed86ab668452b7805593c05073eb2d51d3a52f480a76"
+    }
+  },
+  "get_eth_balance": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xeE728F2fF38b38eBAfE63788032008994764b1fa"
+    }
+  },
+  "get_eth_balance_multiple": {
+    "module": "accounts",
+    "kwargs": {
+      "addresses": [
+        "0xeE728F2fF38b38eBAfE63788032008994764b1fa",
+        "0x63a9975ba31b0b9626b34300f7f627147df1f526",
+        "0x198ef1ec325a96cc354c7266a038be8b5c558f67"
+      ]
+    }
+  },
+  "get_normal_txs_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xeE728F2fF38b38eBAfE63788032008994764b1fa",
+      "startblock": 0,
+      "endblock": 99999999,
+      "sort": "asc"
+    }
+  },
+  "get_normal_txs_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xeE728F2fF38b38eBAfE63788032008994764b1fa",
+      "startblock": 0,
+      "endblock": 99999999,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xeE728F2fF38b38eBAfE63788032008994764b1fa",
+      "startblock": 0,
+      "endblock": 2702578,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x2c1ba59d6f58433fb1eaee7d20b26ed83bda51a3",
+      "startblock": 0,
+      "endblock": 2702578,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_internal_txs_by_txhash": {
+    "module": "accounts",
+    "kwargs": {
+      "txhash": "0x40eb908387324f2b575b4879cd9d7188f69c8fc9d87c901b9e2daaea4b442170"
+    }
+  },
+  "get_internal_txs_by_block_range_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "startblock": 0,
+      "endblock": 2702578,
+      "page": 1,
+      "offset": 10,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x4e83362442b8d1bec281594cea3050c8eb01311c",
+      "startblock": 0,
+      "endblock": 999999999,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_contract_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc20_token_transfer_events_by_address_and_contract_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "address": "0x4e83362442b8d1bec281594cea3050c8eb01311c",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x6975be450864c02b4613023c2152ee0743572325",
+      "startblock": 0,
+      "endblock": 999999999,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_contract_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_erc721_token_transfer_events_by_address_and_contract_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "contract_address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
+      "address": "0x6975be450864c02b4613023c2152ee0743572325",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
+  "get_mined_blocks_by_address": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b"
+    }
+  },
+  "get_mined_blocks_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b",
+      "page": 1,
+      "offset": 100
+    }
+  },
+  "get_hist_eth_balance_for_address_by_block_no": {
+    "module": "pro",
+    "kwargs": {
+      "address": "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+      "block_no": "8000000"
+    }
+  },
+  "get_daily_average_block_size": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_block_count_and_rewards": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_block_rewards": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_average_block_time": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_uncle_block_count_and_rewards": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_hist_erc20_token_total_supply_by_contract_address_and_block_no": {
+    "module": "pro",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055",
+      "block_no": "8000000"
+    }
+  },
+  "get_hist_erc20_token_account_balance_for_token_contract_address_by_block_no": {
+    "module": "pro",
+    "kwargs": {
+      "contract_address": "0x57d90b64a1a57749b0f932f1a3395792e12e7055",
+      "address": "0xe04f27eb70e025b78871a2ad7eabe85e61212761",
+      "block_no": "8000000"
+    }
+  },
+  "get_token_info_by_contract_address": {
+    "module": "pro",
+    "kwargs": {
+      "contract_address": "0x0e3a2a1f2146d86a604adc220b4967a898d7fe07"
+    }
+  },
+  "get_daily_average_gas_limit": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_eth_daily_total_gas_used": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_eth_daily_average_gas_price": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_eth_daily_network_tx_fee": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_new_address_count": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_network_utilization": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_average_network_hash_rate": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_tx_count": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_daily_average_network_difficulty": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_eth_hist_daily_market_cap": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  },
+  "get_eth_hist_price": {
+    "module": "pro",
+    "kwargs": {
+      "start_date": "2019-02-01",
+      "end_date": "2019-02-28",
+      "sort": "asc"
+    }
+  }
+}

--- a/etherscan/etherscan.py
+++ b/etherscan/etherscan.py
@@ -21,10 +21,10 @@ class Etherscan:
             return json.load(f)
 
     @staticmethod
-    def __run(func, api_key: str, net: str):
+    def __run(func, api_key: str, prefix: str):
         def wrapper(*args, **kwargs):
             url = (
-                f"{fields.PREFIX.format(net.lower()).replace('-main','')}"
+                f"{prefix}"
                 f"{func(*args, **kwargs)}"
                 f"{fields.API_KEY}"
                 f"{api_key}"
@@ -37,8 +37,12 @@ class Etherscan:
     @classmethod
     def from_config(cls, api_key: str, config_path: str, net: str):
         config = cls.__load_config(config_path)
+        if "_PREFIX" in config:
+            prefix = config["_PREFIX"]
+        else:
+            prefix = fields.PREFIX.format(net.lower()).replace('-main','')
         for func, v in config.items():
             if not func.startswith("_"):  # disabled if _
                 attr = getattr(getattr(etherscan, v["module"]), func)
-                setattr(cls, func, cls.__run(attr, api_key, net))
+                setattr(cls, func, cls.__run(attr, api_key, prefix))
         return cls

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -23,7 +23,10 @@ def dump(data, fname):
 
 class Case(TestCase):
     _MODULE = ""
-    _NETS = ["MAIN", "KOVAN", "RINKEBY", "ROPSTEN"]
+    if "TEST_ON_NETS" not in os.environ:
+        _NETS = ["MAIN", "KOVAN", "RINKEBY", "ROPSTEN"]
+    else:
+        _NETS = os.environ["TEST_ON_NETS"].split(",")
 
     def methods(self, net):
         print(f"\nNET: {net}")


### PR DESCRIPTION
Adds support for Polygon and Mumbai.

Also changes etherscan.py code to support custom domain (instead of `etherscan.io`) for the networks.