### PR TITLE
Update comment to reflect actual returned value

### DIFF
--- a/etherscan/modules/accounts.py
+++ b/etherscan/modules/accounts.py
@@ -46,7 +46,7 @@ class Accounts:
     def get_normal_txs_by_address(
         address: str, startblock: int, endblock: int, sort: str,
     ) -> str:
-        # NOTE: Returns the last 10k events
+        # NOTE: Returns the first 10k events
         url = (
             f"{fields.MODULE}"
             f"{modules.ACCOUNT}"


### PR DESCRIPTION
For addresses that have more than 10K transactions etherscan.io actually returns the first transactions that are within the start and end blocks.

If you compare the last block returned by the two links below you'll note that they are not the same, if the last 10k transactions were returned they would be the same as the end block is the same in both requests. The last block in first request that starts from block 0 is 5007989 while the last block in the second request that starts from block 5007989 is 5008401.

https://api.etherscan.io/api?module=account&action=txlist&address=0x6ddca767d731f57d90a516dd751f2aa9282b37d2&startblock=000&endblock=99999999&page=1&offset=10000&sort=asc&apikey=YourApiKeyToken

https://api.etherscan.io/api?module=account&action=txlist&address=0x6ddca767d731f57d90a516dd751f2aa9282b37d2&startblock=5007989&endblock=99999999&page=1&offset=10000&sort=asc&apikey=YourApiKeyToken

(Wanted to check the other cases where comments said last but didn't have time to find examples to determine if they also needed to be changed)