### PR TITLE
paginated erc20 by address with specifiable start and end blocks

### DIFF
--- a/etherscan/configs/GOERLI-stable.json
+++ b/etherscan/configs/GOERLI-stable.json
@@ -246,6 +246,15 @@
       "sort": "asc"
     }
   },
+  "get_erc20_token_transfer_events_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x9fc8720759bf397bdc13ae08760a7aea7ebbdf56",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
   "get_erc20_token_transfer_events_by_contract_address_paginated": {
     "module": "accounts",
     "kwargs": {

--- a/etherscan/configs/KOVAN-stable.json
+++ b/etherscan/configs/KOVAN-stable.json
@@ -246,6 +246,15 @@
       "sort": "asc"
     }
   },
+  "get_erc20_token_transfer_events_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0xa991b15e414ddfa78b0df1f7af6b3cf2023c738d",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
   "get_erc20_token_transfer_events_by_contract_address_paginated": {
     "module": "accounts",
     "kwargs": {

--- a/etherscan/configs/MAIN-stable.json
+++ b/etherscan/configs/MAIN-stable.json
@@ -246,6 +246,15 @@
       "sort": "asc"
     }
   },
+  "get_erc20_token_transfer_events_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x4e83362442b8d1bec281594cea3050c8eb01311c",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
   "get_erc20_token_transfer_events_by_contract_address_paginated": {
     "module": "accounts",
     "kwargs": {

--- a/etherscan/configs/RINKEBY-stable.json
+++ b/etherscan/configs/RINKEBY-stable.json
@@ -246,6 +246,15 @@
       "sort": "asc"
     }
   },
+  "get_erc20_token_transfer_events_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x18045cdf3f619e32ff4b11df689059b4d0358d11",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
   "get_erc20_token_transfer_events_by_contract_address_paginated": {
     "module": "accounts",
     "kwargs": {

--- a/etherscan/configs/ROPSTEN-stable.json
+++ b/etherscan/configs/ROPSTEN-stable.json
@@ -246,6 +246,15 @@
       "sort": "asc"
     }
   },
+  "get_erc20_token_transfer_events_by_address_paginated": {
+    "module": "accounts",
+    "kwargs": {
+      "address": "0x3ebe6781be6d436cb7999cfce8b52e40819721cb",
+      "page": 1,
+      "offset": 100,
+      "sort": "asc"
+    }
+  },
   "get_erc20_token_transfer_events_by_contract_address_paginated": {
     "module": "accounts",
     "kwargs": {

--- a/etherscan/modules/accounts.py
+++ b/etherscan/modules/accounts.py
@@ -188,10 +188,35 @@ class Accounts:
             f"{sort}"
         )
         return url
+        
+    @staticmethod
+    def get_erc20_token_transfer_events_by_address_paginated(
+        address: str, page: int, offset: int, startblock: int, endblock: int, sort: str
+    ) -> str:
+
+        url = (
+            f"{fields.MODULE}"
+            f"{modules.ACCOUNT}"
+            f"{fields.ACTION}"
+            f"{actions.TOKENTX}"
+            f"{fields.ADDRESS}"
+            f"{address}"
+            f"{fields.START_BLOCK}"
+            f"{str(startblock)}"
+            f"{fields.END_BLOCK}"
+            f"{str(endblock)}"
+            f"{fields.SORT}"
+            f"{sort}"
+            f"{fields.PAGE}"
+            f"{str(page)}"
+            f"{fields.OFFSET}"
+            f"{str(offset)}"
+        )
+        return url
 
     @staticmethod
     def get_erc20_token_transfer_events_by_contract_address_paginated(
-        contract_address: str, page: int, offset: int, sort: str
+        contract_address: str, page: int, offset: int, startblock: int, endblock: int, sort: str
     ) -> str:
 
         url = (
@@ -201,6 +226,10 @@ class Accounts:
             f"{actions.TOKENTX}"
             f"{fields.CONTRACT_ADDRESS}"
             f"{contract_address}"
+            f"{fields.START_BLOCK}"
+            f"{str(startblock)}"
+            f"{fields.END_BLOCK}"
+            f"{str(endblock)}"
             f"{fields.SORT}"
             f"{sort}"
             f"{fields.PAGE}"
@@ -212,7 +241,7 @@ class Accounts:
 
     @staticmethod
     def get_erc20_token_transfer_events_by_address_and_contract_paginated(
-        contract_address: str, address: str, page: int, offset: int, sort: str
+        contract_address: str, address: str, page: int, offset: int, startblock: int, endblock: int, sort: str
     ) -> str:
 
         url = (
@@ -224,6 +253,10 @@ class Accounts:
             f"{contract_address}"
             f"{fields.ADDRESS}"
             f"{address}"
+            f"{fields.START_BLOCK}"
+            f"{str(startblock)}"
+            f"{fields.END_BLOCK}"
+            f"{str(endblock)}"
             f"{fields.SORT}"
             f"{sort}"
             f"{fields.PAGE}"


### PR DESCRIPTION
Ideally the get_erc20_token_transfer_events_by_address_and_contract_paginated would not force the argument for contract address and some code repetition would be removed. But it would move positional arguments so added in new method